### PR TITLE
prod(py310): deshabilitar CORS por defecto y alinear runtimes a Pytho…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     
-    - name: Set up Python 3.11
+    - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:
-        python-version: '3.11'
+        python-version: '3.10'
     
     - name: Cache pip dependencies
       uses: actions/cache@v3
@@ -172,10 +172,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     
-    - name: Set up Python 3.11
+    - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:
-        python-version: '3.11'
+        python-version: '3.10'
     
     - name: Install linting tools
       run: |

--- a/api.py
+++ b/api.py
@@ -1,11 +1,10 @@
 from typing import Any, Dict
 
+from config import CORS_ALLOW_CREDENTIALS, CORS_ALLOW_HEADERS, CORS_ALLOW_METHODS, CORS_ORIGINS
+from data_store import get_data, get_data_summary, update_data
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
-
-from config import CORS_ALLOW_CREDENTIALS, CORS_ALLOW_HEADERS, CORS_ALLOW_METHODS, CORS_ORIGINS
-from data_store import get_data, get_data_summary, update_data
 from logger import log_api_request, logger
 
 app = FastAPI(

--- a/api/receiver.py
+++ b/api/receiver.py
@@ -26,7 +26,7 @@ app = FastAPI(
 )
 
 # CORS deshabilitado por defecto. Para habilitar, exporta ENABLE_CORS=true y CORS_ORIGINS
-ENABLE_CORS = (os.getenv("ENABLE_CORS", "false").lower() in ("1", "true", "yes"))
+ENABLE_CORS = os.getenv("ENABLE_CORS", "false").lower() in ("1", "true", "yes")
 if ENABLE_CORS:
     ORIGINS = [o for o in (os.getenv("CORS_ORIGINS", "").split(",")) if o]
     if ORIGINS:

--- a/api/receiver.py
+++ b/api/receiver.py
@@ -25,15 +25,19 @@ app = FastAPI(
     redoc_url="/api/receiver/redoc",
 )
 
-# Configurar CORS
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["*"],  # En producción, restringir a dominios específicos
-    allow_credentials=False,
-    allow_methods=["GET", "POST", "OPTIONS"],
-    allow_headers=["Content-Type", "Accept", "User-Agent", "Authorization"],
-    max_age=3600,
-)
+# CORS deshabilitado por defecto. Para habilitar, exporta ENABLE_CORS=true y CORS_ORIGINS
+ENABLE_CORS = (os.getenv("ENABLE_CORS", "false").lower() in ("1", "true", "yes"))
+if ENABLE_CORS:
+    ORIGINS = [o for o in (os.getenv("CORS_ORIGINS", "").split(",")) if o]
+    if ORIGINS:
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=ORIGINS,
+            allow_credentials=False,
+            allow_methods=["GET", "POST", "OPTIONS"],
+            allow_headers=["Content-Type", "Accept", "User-Agent", "Authorization", "x-api-key"],
+            max_age=3600,
+        )
 
 # Configurar rate limiting
 app.state.limiter = limiter

--- a/cache_manager.py
+++ b/cache_manager.py
@@ -3,7 +3,6 @@ from datetime import datetime, timedelta
 from typing import Any, Dict, Optional
 
 import redis
-
 from config import CACHE_TTL, REDIS_URL
 from logger import logger
 

--- a/core/app_core.py
+++ b/core/app_core.py
@@ -51,7 +51,7 @@ class Settings:
     def __init__(self, runtime: str = "local"):
         self.runtime = runtime
         # CORS (deshabilitado por defecto). Para habilitar, establece ENABLE_CORS=true
-        self.enable_cors = (os.getenv("ENABLE_CORS", "false").lower() in ("1", "true", "yes"))
+        self.enable_cors = os.getenv("ENABLE_CORS", "false").lower() in ("1", "true", "yes")
         self.cors_origins = os.getenv("CORS_ORIGINS", "").split(",") if self.enable_cors else []
         self.rate_limit_rpm = int(os.getenv("RATE_LIMIT_RPM", "60"))
         self.http_timeout = int(os.getenv("HTTP_TIMEOUT_SECONDS", "12"))

--- a/core/bot_scraper.py
+++ b/core/bot_scraper.py
@@ -4,9 +4,9 @@ import sys
 from typing import Any, Dict
 
 import requests
-
 from config import API_URL
 from logger import log_scraping_error, log_scraping_start, log_scraping_success, logger
+
 from scraper.finviz import scrape_finviz
 from scraper.tradingview import scrape_tradingview
 from scraper.yahoo import scrape_yahoo

--- a/database.py
+++ b/database.py
@@ -2,11 +2,10 @@ import json
 from datetime import datetime
 from typing import Any, Dict, Optional
 
+from config import DATABASE_URL
 from sqlalchemy import JSON, Column, DateTime, Integer, String, Text, create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
-
-from config import DATABASE_URL
 
 Base = declarative_base()
 

--- a/diagnostic_test.py
+++ b/diagnostic_test.py
@@ -3,7 +3,6 @@ import random
 
 import requests
 from bs4 import BeautifulSoup
-
 from config import FINVIZ_URLS, REQUEST_TIMEOUT, USER_AGENTS, YAHOO_URLS
 
 

--- a/endpoint_generator.py
+++ b/endpoint_generator.py
@@ -1,11 +1,11 @@
 from typing import Any, Dict, List, Optional
 
+from data_store import get_data
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import JSONResponse
+from logger import log_api_request
 
 from cache_manager import cache_manager
-from data_store import get_data
-from logger import log_api_request
 
 
 class EndpointGenerator:

--- a/env.example
+++ b/env.example
@@ -1,5 +1,7 @@
-# CORS Configuration
-CORS_ORIGINS=https://tu-frontend.com,http://localhost:3000
+# CORS Configuration (deshabilitado por defecto)
+# Para habilitar, establece ENABLE_CORS=true y define CORS_ORIGINS
+ENABLE_CORS=false
+CORS_ORIGINS=
 
 # Rate Limiting
 RATE_LIMIT_RPM=60

--- a/investigate_finviz.py
+++ b/investigate_finviz.py
@@ -7,7 +7,6 @@ import random
 
 import requests
 from bs4 import BeautifulSoup
-
 from config import REQUEST_TIMEOUT, USER_AGENTS
 
 

--- a/main.py
+++ b/main.py
@@ -3,14 +3,6 @@ import threading
 
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.interval import IntervalTrigger
-from fastapi import Depends, FastAPI, HTTPException, Request
-from fastapi.middleware.cors import CORSMiddleware
-from fastapi.middleware.gzip import GZipMiddleware
-from fastapi.responses import JSONResponse
-from slowapi import Limiter, _rate_limit_exceeded_handler
-from slowapi.util import get_remote_address
-
-from cache_manager import cache_manager
 from config import (
     CORS_ALLOW_CREDENTIALS,
     CORS_ALLOW_HEADERS,
@@ -20,9 +12,17 @@ from config import (
     SCRAPING_INTERVAL_MINUTES,
 )
 from data_store import get_data, get_data_summary
+from fastapi import Depends, FastAPI, HTTPException, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.middleware.gzip import GZipMiddleware
+from fastapi.responses import JSONResponse
+from logger import log_api_request, logger
+from slowapi import Limiter, _rate_limit_exceeded_handler
+from slowapi.util import get_remote_address
+
+from cache_manager import cache_manager
 from database import init_db
 from endpoint_generator import endpoint_generator
-from logger import log_api_request, logger
 from scraper_manager import scraper_manager
 
 # Rate limiting

--- a/scraper/base_scraper.py
+++ b/scraper/base_scraper.py
@@ -7,7 +7,6 @@ from typing import Any, Dict, List, Optional
 import aiohttp
 import requests
 from bs4 import BeautifulSoup
-
 from config import REQUEST_TIMEOUT, USER_AGENTS
 from logger import logger
 

--- a/scraper/finviz.py
+++ b/scraper/finviz.py
@@ -6,7 +6,6 @@ from typing import Any, Dict, List
 
 import requests
 from bs4 import BeautifulSoup
-
 from config import FINVIZ_URLS, REQUEST_TIMEOUT, USER_AGENTS
 from logger import log_scraping_error, log_scraping_start, log_scraping_success, logger
 

--- a/scraper/tradingview.py
+++ b/scraper/tradingview.py
@@ -1,7 +1,6 @@
 from typing import Any, Dict, List
 
 from bs4 import BeautifulSoup
-
 from config import TRADINGVIEW_URLS
 from logger import logger
 

--- a/scraper/yahoo.py
+++ b/scraper/yahoo.py
@@ -5,7 +5,6 @@ from typing import Any, Dict, List
 
 import requests
 from bs4 import BeautifulSoup
-
 from config import REQUEST_TIMEOUT, USER_AGENTS, YAHOO_URLS
 from logger import log_scraping_error, log_scraping_start, log_scraping_success, logger
 

--- a/scraper_manager.py
+++ b/scraper_manager.py
@@ -2,9 +2,10 @@ import asyncio
 import concurrent.futures
 from typing import Any, Dict, List
 
-from cache_manager import cache_manager
 from data_store import update_data
 from logger import logger
+
+from cache_manager import cache_manager
 from scraper.finviz import FinvizScraper
 from scraper.tradingview import TradingViewScraper
 from scraper.yahoo import YahooScraper

--- a/scraping_diagnostic.py
+++ b/scraping_diagnostic.py
@@ -11,7 +11,6 @@ from typing import Any, Dict, List
 
 import requests
 from bs4 import BeautifulSoup
-
 from config import FINVIZ_URLS, REQUEST_TIMEOUT, TRADINGVIEW_URLS, USER_AGENTS, YAHOO_URLS
 
 

--- a/test_finviz_fix.py
+++ b/test_finviz_fix.py
@@ -11,8 +11,8 @@ sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 import random
 
 import requests
-
 from config import REQUEST_TIMEOUT, USER_AGENTS
+
 from scraper.finviz import scrape_finviz_section_sync
 
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,10 +1,10 @@
 {
   "functions": {
     "api/index.py": {
-      "runtime": "python3.12"
+      "runtime": "python3.10"
     },
     "api/receiver.py": {
-      "runtime": "python3.12"
+      "runtime": "python3.10"
     }
   },
   "regions": ["gru1"],


### PR DESCRIPTION
…n 3.10\n\n- core/app_core.py: CORS opcional via ENABLE_CORS y CORS_ORIGINS\n- api/receiver.py: mismo esquema de CORS opcional\n- env.example: ENABLE_CORS=false y CORS_ORIGINS vacío\n- vercel.json: runtime python3.10 en ambas funciones\n- CI: usar Python 3.10 en jobs test y lint